### PR TITLE
修正PureMVC bug

### DIFF
--- a/PureMVC/Core/Controller.lua
+++ b/PureMVC/Core/Controller.lua
@@ -25,7 +25,7 @@ end
 
 function Controller:executeCommand(notification)
     local commandFunc = self.commandMap[notification:getName()]
-    local commandInstance = commandFunc.new();
+    local commandInstance = commandFunc();
     commandInstance:execute(notification)
 end
 

--- a/PureMVC/Core/Controller.lua
+++ b/PureMVC/Core/Controller.lua
@@ -25,7 +25,7 @@ end
 
 function Controller:executeCommand(notification)
     local commandFunc = self.commandMap[notification:getName()]
-    local commandInstance = commandFunc();
+    local commandInstance = commandFunc.new();
     commandInstance:execute(notification)
 end
 
@@ -39,7 +39,7 @@ end
 function Controller:removeCommand(notificationName)
     if not self:hasCommand(notificationName) then
         return
-    end 
+    end
     self.view:removeObserver(notificationName , self)
     self.commandMap[notificationName] = nil
 end

--- a/PureMVC/Core/View.lua
+++ b/PureMVC/Core/View.lua
@@ -82,6 +82,7 @@ function View:removeMediator(mediatorName)
                 self:removeObserver(v,mediator)
             end
         end
+        self.mediatorMap[mediatorName] = nil
         mediator:onRemove()
     end
     return mediator

--- a/PureMVC/Patterns/Mediator/Mediator.lua
+++ b/PureMVC/Patterns/Mediator/Mediator.lua
@@ -1,4 +1,4 @@
-local Mediator = class("Mediator")
+local Mediator = class("Mediator", Puremvc.Notifier)
 
 function Mediator:ctor(mediatorName ,viewComponent)
     if not mediatorName then

--- a/PureMVC/Patterns/Observer/Observer.lua
+++ b/PureMVC/Patterns/Observer/Observer.lua
@@ -15,8 +15,8 @@ function Observer:notifyObserver(notification)
     end
 end
 
-function Observer:compareNotifyContext(notifyMethod)
-    return self.notifyMethod == notifyMethod
+function Observer:compareNotifyContext(notifyContext)
+    return self.notifyContext == notifyContext
 end
 
 return Observer

--- a/PureMVC/Patterns/Proxy/Proxy.lua
+++ b/PureMVC/Patterns/Proxy/Proxy.lua
@@ -1,4 +1,4 @@
-local Proxy = class("Proxy")
+local Proxy = class("Proxy", Puremvc.Notifier)
 
 function Proxy:ctor(proxyName, data)
     if not proxyName then


### PR DESCRIPTION
修正PureMVC bug
1. Observer:compareNotifyContext 实现错误
2. Mediator 和Proxy 没有继承自Puremvc.Notifier